### PR TITLE
chore: opt GitHub Actions into Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,14 @@ on:
     branches: [ main ]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
## What
- opt this repository into the GitHub-hosted Node 24 runtime for JavaScript actions
- update repo-controlled GitHub Actions majors that currently trigger Node 20 deprecation annotations
- leave `actions/configure-pages@v5` unchanged because it is upstream latest and not repo-controllable here

## Why
- reduce repository-side GitHub Actions deprecation warnings tracked in itdojp/it-engineer-knowledge-architecture#137

## Verification
- `git diff --check`
- `rg "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24|actions/(checkout|cache|upload-artifact|setup-java|upload-pages-artifact)@" .github/workflows -n`

Ref itdojp/it-engineer-knowledge-architecture#137
