### PR TITLE
[codex] improve engineering documentation index guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,3 +74,9 @@ learningOutcomes:
 - [チェックリスト集](appendices/checklists/)
 - [参考文献](appendices/references/)
 - [用語集](appendices/glossary/)
+
+## 利用と更新情報
+
+- ライセンス: CC BY-NC-SA 4.0（商用利用は別契約）
+- リポジトリ: [itdojp/engineering-documentation-book](https://github.com/itdojp/engineering-documentation-book)
+- 更新差分を追う場合は、GitHub のコミット履歴と Pull Request を参照する

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ learningOutcomes:
 ## 前提知識
 
 - Markdown の基本
-- Git/GitHub の基本（Issue/PR）
+- Git/GitHub の基本（Issue / PR）
 
 ## すぐ開く先
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,7 @@ learningOutcomes:
 
 ## 利用と更新情報
 
-- ライセンス: CC BY-NC-SA 4.0（商用利用は別契約）
+- ライセンス: [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja)（このライセンスでは商用利用は許諾されないため、商用利用は別途許諾が必要）
+- 詳細なライセンス条件: [LICENSE.md](https://github.com/itdojp/engineering-documentation-book/blob/main/LICENSE.md)
 - リポジトリ: [itdojp/engineering-documentation-book](https://github.com/itdojp/engineering-documentation-book)
-- 更新差分を追う場合は、GitHub のコミット履歴と Pull Request を参照する
+- 更新差分を追う場合は、GitHub の [コミット履歴](https://github.com/itdojp/engineering-documentation-book/commits/main/) と [PR 一覧](https://github.com/itdojp/engineering-documentation-book/pulls) を参照する


### PR DESCRIPTION
## What changed
- added a `利用と更新情報` section to `docs/index.md`
- clarified the license note and linked the repository as the update source
- directed readers to GitHub commit and PR history for update tracking

## Why
- the top page needed a clearer reader-facing update path without changing chapter structure

## Validation
- `git diff --check`
- `node ../book-formatter/scripts/check-links.js docs`
- `node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on error`