### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -50,7 +50,14 @@
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary
- keep the closed mobile/tablet sidebar drawer off-canvas with `!important` so the later desktop `.book-sidebar { transform: translateX(0); }` rule in `main.css` cannot override it
- document the import-order/cascade reason for the closed-state `!important`
- leave the checked/open drawer rule unchanged so the hamburger menu still opens the TOC

Context: itdojp/it-engineer-knowledge-architecture#168

## Verification
- `npm ci`
- `npm test`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/engineering-doc-bundle-path BUNDLE_APP_CONFIG=/home/devuser/work/CodeX/booksB/.codex-local/tmp/engineering-doc-bundle-config npm run build`
- `git diff --check`
- local Pages visual check with Chromium: `books=1 pages=10 ok=10 warn=0 fail=0`
- direct Playwright probe over `/` and `/chapters/chapter-01/` at 480/768/820/1024/1280 confirmed the closed drawer is off-canvas on <=1024px, the toggle opens it, and desktop layout remains visible
