### PR TITLE
Fix mobile sidebar visibility guard

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -49,7 +49,12 @@
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
+    z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -57,13 +62,13 @@
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
-    transform: translateX(-100%) !important;
-    transition: transform 0.3s ease;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease !important;
   }
   
   /* Ensure sidebar content is interactive */

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -49,12 +49,6 @@
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 999 !important;
-    transform: translateX(-100%) !important;
-    visibility: hidden;
-    transition:
-      transform 0.3s ease,
-      visibility 0s linear 0.3s !important;
     /*
      * main.css imports this file before declaring the default desktop sidebar
      * transform. Keep the closed drawer state important so the later desktop
@@ -62,6 +56,12 @@
      * on mobile and tablet widths. The checked/open rule below is more
      * specific and also important, so the menu button still opens it.
      */
+    z-index: 999 !important;
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s !important;
   }
 
   /* Show sidebar when toggled */


### PR DESCRIPTION
## Summary
- Reinforce the mobile/tablet sidebar closed state with `visibility: hidden` and a delayed visibility transition.
- Keep the opened sidebar visible and above the overlay while preserving the existing off-canvas transform fix.
- This repository has a single tracked `mobile-responsive.css`, so the guard is applied only to that stylesheet.

Part of itdojp/it-engineer-knowledge-architecture#168.

## Verification
- `git diff --check`
- Static CSS guard check for `z-index: 999 !important`, closed `transform: translateX(-100%) !important`, closed `visibility: hidden`, delayed visibility transition, and opened `visibility: visible`.
